### PR TITLE
feat: iterate maps deterministically

### DIFF
--- a/cmd/tableize/main.go
+++ b/cmd/tableize/main.go
@@ -48,7 +48,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		err = enc.Encode(tableize.Tableize(m))
+		err = enc.Encode(tableize.Tableize(&tableize.Input{Value: m}))
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tableize.go
+++ b/tableize.go
@@ -1,6 +1,10 @@
 package tableize
 
-import snakecase "github.com/segmentio/go-snakecase"
+import (
+	"sort"
+
+	snakecase "github.com/segmentio/go-snakecase"
+)
 
 type Input struct {
 	Value map[string]interface{}
@@ -28,7 +32,9 @@ func Tableize(in *Input) map[string]interface{} {
 // redshift, as RS _always_ lowercases the column
 // name in information_schema.columns.
 func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, substitutions map[string]string) {
-	for key, val := range m {
+	keys := getSortedKeys(m)
+	for _, key := range keys {
+		val := m[key]
 		if renamed, ok := substitutions[prefix+key]; ok {
 			key = renamed
 		}
@@ -39,4 +45,13 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 			ret[key] = val
 		}
 	}
+}
+
+func getSortedKeys(m map[string]interface{}) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -1,61 +1,111 @@
-package tableize
+package tableize_test
 
-import "github.com/bmizerany/assert"
-import "encoding/json"
-import "testing"
+import (
+	"encoding/json"
+	"testing"
 
-func check(err error) {
-	if err != nil {
-		panic(err)
-	}
-}
+	. "github.com/segmentio/go-tableize"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestTableize(t *testing.T) {
-	event := map[string]interface{}{
-		"name": map[string]interface{}{
-			"first   name  ": "tobi",
-			"Last-Name":      "holowaychuk",
-			"NickName":       "shupa",
-			"$some_thing":    "tobi",
+	spec := []struct {
+		desc     string
+		input    Input
+		expected map[string]interface{}
+	}{
+		{
+			desc: "simple",
+			input: Input{Value: map[string]interface{}{
+				"species": "ferret",
+			}},
+			expected: map[string]interface{}{
+				"species": "ferret",
+			},
 		},
-		"species": "ferret",
+		{
+			desc: "nested",
+			input: Input{
+				Value: map[string]interface{}{
+					"name": map[string]interface{}{
+						"first": "tobi",
+					},
+				},
+			},
+			expected: map[string]interface{}{"name_first": "tobi"},
+		},
+		{
+			desc: "normalize keys",
+			input: Input{
+				Value: map[string]interface{}{
+					"first   name  ": "tobi",
+					"Last-Name":      "holowaychuk",
+					"NickName":       "shupa",
+					"$some_thing":    "tobi",
+				},
+			},
+			expected: map[string]interface{}{
+				"first_name": "tobi",
+				"last_name":  "holowaychuk",
+				"nick_name":  "shupa",
+				"some_thing": "tobi",
+			},
+		},
+		{
+			desc: "conflicting keys",
+			input: Input{
+				Value: map[string]interface{}{
+					"firstName":   "first_1",
+					"first_name":  "first_2",
+					"lastName":    "last_1",
+					"last_name":   "last_2",
+					"middleName":  "middle_1",
+					"middle_name": "middle_2",
+					"first":       map[string]interface{}{"name": "first_3"},
+					"last":        map[string]interface{}{"name": "last_3"},
+				},
+			},
+			expected: map[string]interface{}{
+				"first_name":  "first_2",
+				"last_name":   "last_2",
+				"middle_name": "middle_2",
+			},
+		},
+		{
+			desc: "substitutions",
+			input: Input{
+				Value: map[string]interface{}{
+					"name": map[string]interface{}{
+						"first   name  ": "tobi",
+						"Last-Name":      "holowaychuk",
+						"NickName":       "shupa",
+						"$some_thing":    "tobi",
+					},
+					"_mid":    "value",
+					"species": "ferret",
+				},
+				Substitutions: map[string]string{
+					"species":          "r_species",
+					"name_$some_thing": "just_some_thing",
+					"_mid":             "u_mid",
+				},
+			},
+			expected: map[string]interface{}{
+				"name_first_name":      "tobi",
+				"name_last_name":       "holowaychuk",
+				"r_species":            "ferret",
+				"name_nick_name":       "shupa",
+				"name_just_some_thing": "tobi",
+				"u_mid":                "value",
+			},
+		},
 	}
 
-	flat := Tableize(&Input{Value: event})
-	assert.Equal(t, flat["name_first_name"], "tobi")
-	assert.Equal(t, flat["name_last_name"], "holowaychuk")
-	assert.Equal(t, flat["species"], "ferret")
-	assert.Equal(t, flat["name_nick_name"], "shupa")
-	assert.Equal(t, flat["name_some_thing"], "tobi")
-}
-
-func TestTableizeWithSubstitution(t *testing.T) {
-	event := map[string]interface{}{
-		"name": map[string]interface{}{
-			"first   name  ": "tobi",
-			"Last-Name":      "holowaychuk",
-			"NickName":       "shupa",
-			"$some_thing":    "tobi",
-		},
-		"_mid":    "value",
-		"species": "ferret",
+	for _, test := range spec {
+		t.Run(test.desc, func(t *testing.T) {
+			assert.Equal(t, test.expected, Tableize(&test.input))
+		})
 	}
-
-	flat := Tableize(&Input{
-		Value: event,
-		Substitutions: map[string]string{
-			"species":          "r_species",
-			"name_$some_thing": "just_some_thing",
-			"_mid":             "u_mid",
-		},
-	})
-
-	assert.Equal(t, flat["name_first_name"], "tobi")
-	assert.Equal(t, flat["name_last_name"], "holowaychuk")
-	assert.Equal(t, flat["r_species"], "ferret")
-	assert.Equal(t, flat["name_nick_name"], "shupa")
-	assert.Equal(t, flat["name_just_some_thing"], "tobi")
-	assert.Equal(t, flat["u_mid"], "value")
 }
 
 func BenchmarkSmall(b *testing.B) {
@@ -202,5 +252,11 @@ func BenchmarkLarge(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		Tableize(&Input{Value: event})
+	}
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
 	}
 }


### PR DESCRIPTION
This is the library responsible for "flattening" our JSON. Since golang iterates maps in random order, this can lead to nondeterministic output in cases where multiple keys conflict (ie: snakecase to the same value such as "first_name" and "firstName")

The primary function of this PR is to address the nondeterministic nature of this library by determining the map keys and sorting them before iteration. The result remains deterministic even if nested values clobber across different levels. (eg: "first.name" and "first_name") In the case of a conflict, the last value in the sorted order will always win. For example, "firstName" will always be preferred over "first_name" due to `sort.Strings()`.

We should decide now if we want to have the winning value be the first or last value, as once we change this it probably won't be wise to change it.