### PR TITLE
Support arrays

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
-module example.com/m/v2
+module github.com/segmentio/go-tableize
 
 go 1.16
 
 require (
+	github.com/segmentio/encoding v0.2.19
 	github.com/segmentio/go-snakecase v1.2.0
-	github.com/segmentio/go-tableize v2.0.0+incompatible
 	github.com/stretchr/testify v1.7.0
 	github.com/tj/docopt v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,13 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/klauspost/cpuid/v2 v2.0.5 h1:qnfhwbFriwDIX51QncuNU5mEMf+6KE3t7O8V2KQl3Dg=
+github.com/klauspost/cpuid/v2 v2.0.5/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/segmentio/encoding v0.2.19 h1:Kshkmoz080qvUtdtakR8Bjk2sIlLS8wSvijFMEHRGow=
+github.com/segmentio/encoding v0.2.19/go.mod h1:7E68jTSWMnNoYhHi1JbLd7NBSB6XfE4vzqhR88hDBQc=
 github.com/segmentio/go-snakecase v1.2.0 h1:4cTmEjPGi03WmyAHWBjX53viTpBkn/z+4DO++fqYvpw=
 github.com/segmentio/go-snakecase v1.2.0/go.mod h1:jk1miR5MS7Na32PZUykG89Arm+1BUSYhuGR6b7+hJto=
-github.com/segmentio/go-tableize v2.0.0+incompatible h1:5Z2sZud6aYPqdYgvRuIVdL2D9ciWFp+1UPcbmg3aMZY=
-github.com/segmentio/go-tableize v2.0.0+incompatible/go.mod h1:igu8uNdIUFCr6TpLHo1ZOcWRCNK7jV+bemtqf4mGT3Y=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/tableize.go
+++ b/tableize.go
@@ -13,9 +13,9 @@ type Input struct {
 	Value map[string]interface{}
 
 	// Optional
-	HintSize      int
-	Substitutions map[string]string
-	StringifyArrays  bool
+	HintSize        int
+	Substitutions   map[string]string
+	StringifyArrays bool
 }
 
 // Tableize the given map by flattening and normalizing all

--- a/tableize.go
+++ b/tableize.go
@@ -3,6 +3,7 @@ package tableize
 import (
 	"sort"
 
+	"github.com/segmentio/encoding/json"
 	snakecase "github.com/segmentio/go-snakecase"
 )
 
@@ -50,6 +51,9 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 		switch t := val.(type) {
 		case map[string]interface{}:
 			visit(ret, t, key+"_", substitutions)
+		case []interface{}:
+			b, _ := json.Marshal(val)
+			ret[key] = string(b)
 		default:
 			ret[key] = val
 		}

--- a/tableize.go
+++ b/tableize.go
@@ -68,7 +68,6 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 			ret[key] = val
 		}
 	}
-
 }
 
 func getSortedKeys(m map[string]interface{}) []string {

--- a/tableize.go
+++ b/tableize.go
@@ -15,7 +15,7 @@ type Input struct {
 	// Optional
 	HintSize      int
 	Substitutions map[string]string
-	StringifyArr  bool
+	StringifyArrays  bool
 }
 
 // Tableize the given map by flattening and normalizing all
@@ -26,7 +26,7 @@ func Tableize(in *Input) map[string]interface{} {
 	}
 
 	ret := make(map[string]interface{}, in.HintSize)
-	visit(ret, in.Value, "", in.Substitutions, in.StringifyArr)
+	visit(ret, in.Value, "", in.Substitutions, in.StringifyArrays)
 	return ret
 }
 
@@ -57,7 +57,7 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 			if stringifyArr {
 				valByteArr, err := json.Marshal(val)
 				if err != nil {
-					log.Printf("[Error] Unable to marshall value `%v` err: %v", val, err)
+					log.Printf("go-tableize: dropping array value %+v that could not be converted to string: %s\n", val, err)
 				} else {
 					ret[key] = string(valByteArr)
 				}

--- a/tableize.go
+++ b/tableize.go
@@ -50,7 +50,6 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 		}
 		key = prefix + snakecase.Snakecase(key)
 
-		key = prefix + snakecase.Snakecase(key)
 		switch t := val.(type) {
 		case map[string]interface{}:
 			visit(ret, t, key+"_", substitutions, stringifyArr)

--- a/tableize.go
+++ b/tableize.go
@@ -50,32 +50,26 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 		}
 		key = prefix + snakecase.Snakecase(key)
 
-		for _, key := range keys {
-			val = m[key]
-			if renamed, ok = substitutions[prefix+key]; ok {
-				key = renamed
-			}
-			key = prefix + snakecase.Snakecase(key)
-			switch t := val.(type) {
-			case map[string]interface{}:
-				visit(ret, t, key+"_", substitutions, stringifyArr)
-			case []interface{}:
-				if stringifyArr {
-					valByteArr, err := json.Marshal(val)
-					if err != nil {
-						log.Printf("[Error] Unable to marshall value `%v` err: %v", val, err)
-					} else {
-						ret[key] = string(valByteArr)
-					}
+		key = prefix + snakecase.Snakecase(key)
+		switch t := val.(type) {
+		case map[string]interface{}:
+			visit(ret, t, key+"_", substitutions, stringifyArr)
+		case []interface{}:
+			if stringifyArr {
+				valByteArr, err := json.Marshal(val)
+				if err != nil {
+					log.Printf("[Error] Unable to marshall value `%v` err: %v", val, err)
 				} else {
-					ret[key] = val
+					ret[key] = string(valByteArr)
 				}
-			default:
+			} else {
 				ret[key] = val
 			}
+		default:
+			ret[key] = val
 		}
-
 	}
+
 }
 
 func getSortedKeys(m map[string]interface{}) []string {

--- a/tableize.go
+++ b/tableize.go
@@ -35,7 +35,7 @@ func Tableize(in *Input) map[string]interface{} {
 // are mapped correctly to the schema fetched from
 // redshift, as RS _always_ lowercases the column
 // name in information_schema.columns.
-func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, substitutions map[string]string, stringifyArr bool) {
+func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, substitutions map[string]string, stringifyArrays bool) {
 	var val interface{}
 	var renamed string
 	var ok bool
@@ -52,9 +52,9 @@ func visit(ret map[string]interface{}, m map[string]interface{}, prefix string, 
 
 		switch t := val.(type) {
 		case map[string]interface{}:
-			visit(ret, t, key+"_", substitutions, stringifyArr)
+			visit(ret, t, key+"_", substitutions, stringifyArrays)
 		case []interface{}:
-			if stringifyArr {
+			if stringifyArrays {
 				valByteArr, err := json.Marshal(val)
 				if err != nil {
 					log.Printf("go-tableize: dropping array value %+v that could not be converted to string: %s\n", val, err)

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -152,7 +152,7 @@ func TestTableizeArray(t *testing.T) {
 			},
 		},
 		{
-			desc: "simple arr StringifyArr=true",
+			desc: "simple arr StringifyArrays=true",
 			input: Input{Value: map[string]interface{}{
 				"colors": []interface{}{"red", "blue"},
 			}, StringifyArrays: true,
@@ -162,7 +162,7 @@ func TestTableizeArray(t *testing.T) {
 			},
 		},
 		{
-			desc: "simple arr StringifyArr=false",
+			desc: "simple arr StringifyArrays=false",
 			input: Input{Value: map[string]interface{}{
 				"colors": []interface{}{"red", "blue"},
 			}, StringifyArrays: false,

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -116,7 +116,7 @@ func TestTableizeArray(t *testing.T) {
 	prop := make(map[string]interface{})
 	dec.Decode(&prop)
 	var arr []interface{}
-	arr = append(arr,"a@b.com", "service@v.com.au")
+	arr = append(arr, "a@b.com", "service@v.com.au")
 	marshal, _ := json.Marshal(arr)
 	arrStr := string(marshal)
 	spec := []struct {
@@ -125,31 +125,31 @@ func TestTableizeArray(t *testing.T) {
 		expected map[string]interface{}
 	}{
 		{
-			desc: "array inside big JSON",
+			desc:  "array inside big JSON",
 			input: Input{Value: prop, StringifyArr: true},
 			expected: map[string]interface{}{
-				"context_latitude" : nil,
-				"context_location" : nil,
-				"event_type" : "FacebookComment",
-				"graph_object_id" : "null",
-				"program" : "source-runner",
-				"ticket_event_id" : json.Number("17820988764"),
-				"ticket_event_via" : "Mail",
-				"ticket_id" : "357276",
-				"trusted" : true,
-				"via_source_rel" : nil,
-				"via_source_to_address" : nil,
-				"context_client" : nil,
-				"context_longitude" : nil,
-				"data" : "{\"via_zendesk\":true}",
-				"via_source_from_address" : nil,
-				"via_source_from_name" : "a b",
-				"via_source_from_original_recipients" : arrStr,
-				"timestamp" : "2014-07-18T04:12:42.000Z",
-				"updater_id" : "473752564",
-				"version" : "8bc54c3",
-				"via_channel" : "email",
-				"via_source_to_name" : "companyName",
+				"context_latitude":                    nil,
+				"context_location":                    nil,
+				"event_type":                          "FacebookComment",
+				"graph_object_id":                     "null",
+				"program":                             "source-runner",
+				"ticket_event_id":                     json.Number("17820988764"),
+				"ticket_event_via":                    "Mail",
+				"ticket_id":                           "357276",
+				"trusted":                             true,
+				"via_source_rel":                      nil,
+				"via_source_to_address":               nil,
+				"context_client":                      nil,
+				"context_longitude":                   nil,
+				"data":                                "{\"via_zendesk\":true}",
+				"via_source_from_address":             nil,
+				"via_source_from_name":                "a b",
+				"via_source_from_original_recipients": arrStr,
+				"timestamp":                           "2014-07-18T04:12:42.000Z",
+				"updater_id":                          "473752564",
+				"version":                             "8bc54c3",
+				"via_channel":                         "email",
+				"via_source_to_name":                  "companyName",
 			},
 		},
 		{
@@ -172,7 +172,7 @@ func TestTableizeArray(t *testing.T) {
 				"colors": []interface{}{"red", "blue"},
 			},
 		},
-	}                                                                                          
+	}
 
 	for _, test := range spec {
 		t.Run(test.desc, func(t *testing.T) {

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -126,7 +126,7 @@ func TestTableizeArray(t *testing.T) {
 	}{
 		{
 			desc:  "array inside big JSON",
-			input: Input{Value: prop, StringifyArr: true},
+			input: Input{Value: prop, StringifyArrays: true},
 			expected: map[string]interface{}{
 				"context_latitude":                    nil,
 				"context_location":                    nil,
@@ -156,7 +156,7 @@ func TestTableizeArray(t *testing.T) {
 			desc: "simple arr StringifyArr=true",
 			input: Input{Value: map[string]interface{}{
 				"colors": []interface{}{"red", "blue"},
-			}, StringifyArr: true,
+			}, StringifyArrays: true,
 			},
 			expected: map[string]interface{}{
 				"colors": "[\"red\",\"blue\"]",
@@ -166,7 +166,7 @@ func TestTableizeArray(t *testing.T) {
 			desc: "simple arr StringifyArr=false",
 			input: Input{Value: map[string]interface{}{
 				"colors": []interface{}{"red", "blue"},
-			}, StringifyArr: false,
+			}, StringifyArrays: false,
 			},
 			expected: map[string]interface{}{
 				"colors": []interface{}{"red", "blue"},

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -3,7 +3,6 @@ package tableize_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	. "github.com/segmentio/go-tableize"
@@ -111,21 +110,14 @@ func TestTableize(t *testing.T) {
 }
 
 func TestTableizeArray(t *testing.T) {
-	str := "{    \"context_client\": null,\n    \"context_latitude\": null,\n    \"context_location\": null,\n    \"context_longitude\": null,\n    \"data\": \"{\\\"via_zendesk\\\":true}\",\n    \"event_type\": \"FacebookComment\",\n    \"graph_object_id\": \"null\",\n    \"program\": \"source-runner\",\n    \"ticket_event_id\": 17820988764,\n    \"ticket_event_via\": \"Mail\",\n    \"ticket_id\": \"357276\",\n    \"timestamp\": \"2014-07-18T04:12:42.000Z\",\n    \"trusted\": true,\n    \"updater_id\": \"473752564\",\n    \"version\": \"8bc54c3\",\n    \"via\": {\n      \"channel\": \"email\",\n      \"source\": {\n        \"from\": {\n          \"address\": null,\n          \"name\": \"a b\",\n          \"original_recipients\": [\n            \"a@b.com\",\n            \"service@v.com.au\"\n          ]\n        },\n        \"rel\": null,\n        \"to\": {\n          \"address\": null,\n          \"name\": \"amaysim\"\n        }\n      }\n    }\n}"
+	jsonStr := "{    \"context_client\": null,\n    \"context_latitude\": null,\n    \"context_location\": null,\n    \"context_longitude\": null,\n    \"data\": \"{\\\"via_zendesk\\\":true}\",\n    \"event_type\": \"FacebookComment\",\n    \"graph_object_id\": \"null\",\n    \"program\": \"source-runner\",\n    \"ticket_event_id\": 17820988764,\n    \"ticket_event_via\": \"Mail\",\n    \"ticket_id\": \"357276\",\n    \"timestamp\": \"2014-07-18T04:12:42.000Z\",\n    \"trusted\": true,\n    \"updater_id\": \"473752564\",\n    \"version\": \"8bc54c3\",\n    \"via\": {\n      \"channel\": \"email\",\n      \"source\": {\n        \"from\": {\n          \"address\": null,\n          \"name\": \"a b\",\n          \"original_recipients\": [\n            \"a@b.com\",\n            \"service@v.com.au\"\n          ]\n        },\n        \"rel\": null,\n        \"to\": {\n          \"address\": null,\n          \"name\": \"companyName\"\n        }\n      }\n    }\n}"
+	dec := json.NewDecoder(bytes.NewReader([]byte(jsonStr)))
+	dec.UseNumber()
 	prop := make(map[string]interface{})
-	var properties []byte
-	properties = []byte(str)
-	if len(properties) > 0 {
-		dec := json.NewDecoder(bytes.NewReader(properties))
-		dec.UseNumber()
-		if err := dec.Decode(&prop); err != nil {
-			fmt.Println(err.Error())
-		}
-	}
-	//flatMap := Tableize(&Input{Value: prop})
+	dec.Decode(&prop)
 	var arr []interface{}
 	arr = append(arr,"a@b.com", "service@v.com.au")
-	marshal, _ := json.Marshal(arr)//"[]interface {}[\"a@b.com\",\"service@v.com.au\"]"
+	marshal, _ := json.Marshal(arr)
 	arrStr := string(marshal)
 	spec := []struct {
 		desc     string
@@ -133,8 +125,8 @@ func TestTableizeArray(t *testing.T) {
 		expected map[string]interface{}
 	}{
 		{
-			desc: "array inside",
-			input: Input{Value: prop/*flatMap*/, StringifyArr: true},
+			desc: "array inside big JSON",
+			input: Input{Value: prop, StringifyArr: true},
 			expected: map[string]interface{}{
 				"context_latitude" : nil,
 				"context_location" : nil,
@@ -157,7 +149,7 @@ func TestTableizeArray(t *testing.T) {
 				"updater_id" : "473752564",
 				"version" : "8bc54c3",
 				"via_channel" : "email",
-				"via_source_to_name" : "amaysim",
+				"via_source_to_name" : "companyName",
 			},
 		},
 		{

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -1,11 +1,10 @@
-package tableize_test
+package tableize
 
 import (
 	"bytes"
 	"encoding/json"
 	"testing"
 
-	. "github.com/segmentio/go-tableize"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tableize_test.go
+++ b/tableize_test.go
@@ -1,6 +1,9 @@
 package tableize_test
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	. "github.com/segmentio/go-tableize"
@@ -99,6 +102,85 @@ func TestTableize(t *testing.T) {
 			},
 		},
 	}
+
+	for _, test := range spec {
+		t.Run(test.desc, func(t *testing.T) {
+			assert.Equal(t, test.expected, Tableize(&test.input))
+		})
+	}
+}
+
+func TestTableizeArray(t *testing.T) {
+	str := "{    \"context_client\": null,\n    \"context_latitude\": null,\n    \"context_location\": null,\n    \"context_longitude\": null,\n    \"data\": \"{\\\"via_zendesk\\\":true}\",\n    \"event_type\": \"FacebookComment\",\n    \"graph_object_id\": \"null\",\n    \"program\": \"source-runner\",\n    \"ticket_event_id\": 17820988764,\n    \"ticket_event_via\": \"Mail\",\n    \"ticket_id\": \"357276\",\n    \"timestamp\": \"2014-07-18T04:12:42.000Z\",\n    \"trusted\": true,\n    \"updater_id\": \"473752564\",\n    \"version\": \"8bc54c3\",\n    \"via\": {\n      \"channel\": \"email\",\n      \"source\": {\n        \"from\": {\n          \"address\": null,\n          \"name\": \"a b\",\n          \"original_recipients\": [\n            \"a@b.com\",\n            \"service@v.com.au\"\n          ]\n        },\n        \"rel\": null,\n        \"to\": {\n          \"address\": null,\n          \"name\": \"amaysim\"\n        }\n      }\n    }\n}"
+	prop := make(map[string]interface{})
+	var properties []byte
+	properties = []byte(str)
+	if len(properties) > 0 {
+		dec := json.NewDecoder(bytes.NewReader(properties))
+		dec.UseNumber()
+		if err := dec.Decode(&prop); err != nil {
+			fmt.Println(err.Error())
+		}
+	}
+	//flatMap := Tableize(&Input{Value: prop})
+	var arr []interface{}
+	arr = append(arr,"a@b.com", "service@v.com.au")
+	marshal, _ := json.Marshal(arr)//"[]interface {}[\"a@b.com\",\"service@v.com.au\"]"
+	arrStr := string(marshal)
+	spec := []struct {
+		desc     string
+		input    Input
+		expected map[string]interface{}
+	}{
+		{
+			desc: "array inside",
+			input: Input{Value: prop/*flatMap*/, StringifyArr: true},
+			expected: map[string]interface{}{
+				"context_latitude" : nil,
+				"context_location" : nil,
+				"event_type" : "FacebookComment",
+				"graph_object_id" : "null",
+				"program" : "source-runner",
+				"ticket_event_id" : json.Number("17820988764"),
+				"ticket_event_via" : "Mail",
+				"ticket_id" : "357276",
+				"trusted" : true,
+				"via_source_rel" : nil,
+				"via_source_to_address" : nil,
+				"context_client" : nil,
+				"context_longitude" : nil,
+				"data" : "{\"via_zendesk\":true}",
+				"via_source_from_address" : nil,
+				"via_source_from_name" : "a b",
+				"via_source_from_original_recipients" : arrStr,
+				"timestamp" : "2014-07-18T04:12:42.000Z",
+				"updater_id" : "473752564",
+				"version" : "8bc54c3",
+				"via_channel" : "email",
+				"via_source_to_name" : "amaysim",
+			},
+		},
+		{
+			desc: "simple arr StringifyArr=true",
+			input: Input{Value: map[string]interface{}{
+				"colors": []interface{}{"red", "blue"},
+			}, StringifyArr: true,
+			},
+			expected: map[string]interface{}{
+				"colors": "[\"red\",\"blue\"]",
+			},
+		},
+		{
+			desc: "simple arr StringifyArr=false",
+			input: Input{Value: map[string]interface{}{
+				"colors": []interface{}{"red", "blue"},
+			}, StringifyArr: false,
+			},
+			expected: map[string]interface{}{
+				"colors": []interface{}{"red", "blue"},
+			},
+		},
+	}                                                                                          
 
 	for _, test := range spec {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
## Description
This PR adds the option to support arrays while flattening map.
This was originally raised by failure reported in this ticket: https://segment.atlassian.net/browse/SRC-2564
The change is backward compatible. Only if explicitly setting `StringifyArr=true`, then array will be stringified

## Testing 
Added relevant unit tests

## Deployment 
Merge to master

## Rollback procedure
Revert this PR from master